### PR TITLE
Simplify and make more generic

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,41 +1,37 @@
 module.exports = {
-    parser: '@typescript-eslint/parser', // Specifies the ESLint parser
-    parserOptions: {
-      ecmaVersion: 2020, // Allows for the parsing of modern ECMAScript features
-      sourceType: 'module', // Allows for the use of imports
-      ecmaFeatures: {
-        jsx: true, // Allows for the parsing of JSX
-      },
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
     },
-    settings: {
-      react: {
-        version: 'detect', // Tells eslint-plugin-react to automatically detect the version of React to use
-      },
+  },
+  settings: {
+    react: {
+      version: 'detect',
     },
-    extends: [
-      'plugin:@typescript-eslint/recommended', // Uses the recommended rules from the @typescript-eslint/eslint-plugin
-      'prettier/@typescript-eslint', // Uses eslint-config-prettier to disable ESLint rules from @typescript-eslint/eslint-plugin that would conflict with prettier
-      'plugin:prettier/recommended', // Enables eslint-plugin-prettier and eslint-config-prettier. This will display prettier errors as ESLint errors. Make sure this is always the last configuration in the extends array.
+  },
+  extends: [
+    'plugin:@typescript-eslint/recommended',
+    'prettier/@typescript-eslint',
+    'plugin:prettier/recommended', // Must be last in the extends array
+  ],
+  plugins: ['sort-imports-es6-autofix'],
+  rules: {
+    'sort-imports-es6-autofix/sort-imports-es6': [
+      2,
+      {
+        ignoreCase: false,
+        ignoreMemberSort: false,
+        memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single'],
+      },
     ],
-  
-    plugins: ['sort-imports-es6-autofix'],
-    rules: {
-      'sort-imports-es6-autofix/sort-imports-es6': [
-        2,
-        {
-          ignoreCase: false,
-          ignoreMemberSort: false,
-          memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single'],
-        },
-      ],
-      // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
-      // e.g. "@typescript-eslint/explicit-function-return-type": "off",
-      'prettier/prettier': [
-        'error',
-        {
-          endOfLine: 'auto',
-        },
-      ],
-    },
-  };
-  
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,27 +1,14 @@
-# See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
-
-# dependencies
-/node_modules
-/.pnp
-.pnp.js
-
-# testing
-/coverage
-
-# production
-/build
-/dist
-
-# misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
+.env*
+.eslintcache
+.pnp.js
+/.pnp
+/build
+/coverage
+/dist
+/node_modules
 npm-debug.log*
+package-lock.json
 yarn-debug.log*
 yarn-error.log*
 yarn.lock
-package-lock.json
-.eslintcache

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/README.md
+++ b/README.md
@@ -1,23 +1,29 @@
-# Typescript GUI Template
-This is a template repository for new projects. When you create a new repository from this template, follow these instructions:
+# Typescript project template
 
-1. Make sure the `.gitignore` file is appropriate for your project
-2. Update package.json properties to describe the package:
-   - `name`
-   - `version`
-   - `description`
-3. Setup `@nengo/commitlint-config-nengo`
-   - Instructions [here](https://github.com/nengo/commitlint-config-nengo#setup)
-4. Install dependecies with `npm install`
-5. Setup testing:
-   1. Remove the `--passWithNoTests` flag from `test-coverage` script in `package.json`
-   2. The project defaults to checking for tests in the `/utils` folder. You can modify the folders to check for tests in `package.json`
-   ```json
-   "jest":{
-      "collectCoverageFrom": [
-         "<rootDir>/src/utils/**/*.ts",
-         ...
-      ]
-   }
-   ```
+This is a template repository for new Typescript projects.
+When you create a new repository from this template, follow these instructions:
+
+1. Make sure the `.gitignore` file is appropriate for your project.
+
+2. Replace the TODO keys like `name` and `description` in `package.json`.
+
+3. [Set up `@nengo/commitlint-config-nengo`.](https://github.com/nengo/commitlint-config-nengo#setup)
+
+4. Install dependecies with `npm install`.
+
+5. Set up testing in `package.json`:
+
+   1. Remove the `--passWithNoTests` flag from the `test-coverage` script.
+
+   2. Modify the test collection rules, if appropriate.
+
+      ```json
+      "jest": {
+         "collectCoverageFrom": [
+            "<rootDir>/src/utils/**/*.ts",
+            ...
+         ]
+      }
+      ```
+
 6. Replace the text in `README.md` with text for the new repository.

--- a/package.json
+++ b/package.json
@@ -1,21 +1,13 @@
 {
-  "name": "template-ts",
-  "version": "1.0.0",
-  "description": "description",
+  "name": "TODO",
+  "version": "0.0.1",
+  "description": "TODO",
   "main": "dist/index.js",
-  "dependencies": {
-    "@types/react": "^17.0.1",
-    "@types/react-dom": "^17.0.1",
-    "@types/styled-components": "^5.1.7",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
-    "styled-components": "^5.2.1"
-  },
+  "dependencies": {},
   "jest": {
     "collectCoverageFrom": [
       "<rootDir>/src/utils/**/*.ts",
-      "!<rootDir>/src/components/**/*.tsx",
-      "!<rootDir>/node_modules",
+      "!<rootDir>/node_modules/",
       "!<rootDir>/dist/"
     ],
     "testPathIgnorePatterns": [
@@ -39,18 +31,9 @@
     "extends": "@nengo/commitlint-config-nengo"
   },
   "scripts": {
-    "build": "tsc",
     "test": "jest --watchAll",
     "test-coverage": "jest --collectCoverage --passWithNoTests",
     "lint-commits": "commitlint --from main --to HEAD --verbose"
-  },
-  "watch": {
-    "build": {
-      "patterns": [
-        "src"
-      ],
-      "extensions": "ts,tsx"
-    }
   },
   "husky": {
     "hooks": {
@@ -99,7 +82,6 @@
     "husky": "^4.3.0",
     "jest": "^26.6.0",
     "lint-staged": "^10.5.1",
-    "prettier": "^2.1.2",
-    "typescript": "^4.0.3"
+    "prettier": "^2.1.2"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
-"compilerOptions": {
+  "compilerOptions": {
     "baseUrl": "src",
     "target": "es5",
     "lib": [
-    "dom",
-    "dom.iterable",
-    "esnext"
+      "dom",
+      "dom.iterable",
+      "esnext"
     ],
     "allowJs": true,
     "skipLibCheck": true,
@@ -21,7 +21,8 @@
     "jsx": "react",
     "outDir": "dist",
     "noImplicitAny": false
-},
-"include": ["src"]
+  },
+  "include": [
+    "src"
+  ]
 }
-  


### PR DESCRIPTION
- Ran prettier on all files
- Removed comments from .eslintrc.js
- Removed comments from .gitignore and sorted lines alphbetically
- Minor style changes to README.md
- Changed some things to TODO in package.json
- Removed pre-specified dependencies

I also made this repo public and marked it as a template, but didn't end up renaming it to `template-js` because a lot of our checks and hooks are set up for TypeScript projects and removing all of those things would make the template less useful because then there would still be a lot of manual set up steps after using the template.